### PR TITLE
[C] Remove cors header from default.conf

### DIFF
--- a/config-env/default.conf
+++ b/config-env/default.conf
@@ -20,7 +20,7 @@ server {
         try_files $uri $uri/ /index.php?$query_string;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass skyviewer_api:9000;
-        add_header Access-Control-Allow-Origin *; # This allows for CORS requests
+      # add_header Access-Control-Allow-Origin *; # This allows for CORS requests
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;


### PR DESCRIPTION
Craft 3 already sets this header, so setting it again was throwing a "multiple headers" error in the browser: https://github.com/craftcms/cms/issues/4830