### PR TITLE
Fix craft upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Composer dependencies
 FROM composer:2 as vendor
 COPY craftcms/composer.json composer.json
-COPY craftcms/composer.lock composer.lock
+# COPY craftcms/composer.lock composer.lock
 COPY custom-plugins/ ../custom-plugins/
 RUN composer install --ignore-platform-reqs --no-interaction --prefer-dist --classmap-authoritative
 

--- a/craftcms/composer.json
+++ b/craftcms/composer.json
@@ -1,13 +1,19 @@
 {
   "minimum-stability": "dev",
   "prefer-stable": true,
+  "repositories": [
+    {
+      "type": "path",
+      "url": "../custom-plugins/nested-entry-graphql-queries"
+    }
+  ],
   "require": {
     "craftcms/cms": "3.7.17.1", 
     "craftcms/google-cloud": "^1.4",
     "craftcms/redactor": "2.8.8",
     "ether/logs": "3.0.4",
     "google/cloud-storage": "^1.24",
-    "rosas/nested-entries-graphql-queries": "dev-develop",
+    "rosas/nested-entries-graphql-queries": "dev-master",
     "vlucas/phpdotenv": "^3.4.0"
   },
   "require-dev": {


### PR DESCRIPTION
This push allows the ability to upgrade the CraftCMS version via only the `composer.json` file. Currently an upgrade results in a version mismatch between the `compose.json` and `composer.lock` files, resulting in the previous version still being installed. It should resolve the current 503 errors on the skyviewer-api dev service.