### PR TITLE
[B] Github workflows have correct main branch refs for gcloud

### DIFF
--- a/.github/workflows/gae-pr-develop.yaml
+++ b/.github/workflows/gae-pr-develop.yaml
@@ -23,7 +23,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: skyviewer
@@ -71,7 +71,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: skyviewer

--- a/.github/workflows/gae-pr-master.yaml
+++ b/.github/workflows/gae-pr-master.yaml
@@ -23,7 +23,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e
@@ -71,7 +71,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e

--- a/.github/workflows/gae-push-develop.yaml
+++ b/.github/workflows/gae-push-develop.yaml
@@ -18,7 +18,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: skyviewer

--- a/.github/workflows/gae-push-master.yaml
+++ b/.github/workflows/gae-push-master.yaml
@@ -18,7 +18,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e

--- a/.github/workflows/master-pr.yaml
+++ b/.github/workflows/master-pr.yaml
@@ -24,7 +24,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e
@@ -87,7 +87,7 @@ jobs:
     steps:
       # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e

--- a/.github/workflows/master-push.yaml
+++ b/.github/workflows/master-push.yaml
@@ -18,7 +18,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.SKYVIEWER_INT_SERVICE_ACCOUNT }}
         project_id: edc-int-6c5e

--- a/.github/workflows/pr-dev-skyviewer-api.yaml
+++ b/.github/workflows/pr-dev-skyviewer-api.yaml
@@ -28,7 +28,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: ${{ secrets.SV_PROJ_NAME }}
@@ -90,7 +90,7 @@ jobs:
     steps:
       # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: ${{ secrets.SV_PROJ_NAME }}

--- a/.github/workflows/push-dev-skyviewer-api.yaml
+++ b/.github/workflows/push-dev-skyviewer-api.yaml
@@ -18,7 +18,7 @@ jobs:
 
     # gcloud CLI setup
     - name: Login to GCP
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       with:
         service_account_key: ${{ secrets.DEV_SA_KEY }}
         project_id: ${{ secrets.SV_PROJ_NAME }}


### PR DESCRIPTION
```
Error: On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.
```

Following suggestion:
```
We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'
```

Seems like it's done the trick.